### PR TITLE
Refactor API usage and clean up server

### DIFF
--- a/backend/models/Contact.js
+++ b/backend/models/Contact.js
@@ -14,6 +14,10 @@ const ContactSchema = new mongoose.Schema(
       type: String,
       required: true,
     },
+    services: {
+      type: [String],
+      required: true,
+    },
     date: {
       type: Date,
       default: Date.now,

--- a/backend/models/Project.js
+++ b/backend/models/Project.js
@@ -11,8 +11,6 @@ const ProjectSchema = new mongoose.Schema({
   eindklant: { type: String, default: "Niet gespecificeerd" },
   liveLink: { type: String },
   githubLink: { type: String },
-  opdrachtgever: { type: String }, 
-  eindklant: { type: String },
 });
 
 module.exports = mongoose.model("Project", ProjectSchema);

--- a/backend/models/Service.js
+++ b/backend/models/Service.js
@@ -1,9 +1,7 @@
 const mongoose = require("mongoose");
-const AutoIncrement = require("mongoose-sequence")(mongoose); // Voor auto-increment
 
 const serviceSchema = new mongoose.Schema(
   {
-    id: { type: Number, unique: true }, // Automatisch geïncrementeerd veld
     name: { type: String, required: true, trim: true }, // Trim voor betere validatie
     description: { type: String, required: true, trim: true },
     details: { type: String, trim: true },
@@ -14,8 +12,4 @@ const serviceSchema = new mongoose.Schema(
   }
 );
 
-// Voeg auto-increment toe aan het `id` veld
-serviceSchema.plugin(AutoIncrement, { inc_field: "id" });
-
-// Exporteer het model
 module.exports = mongoose.model("Service", serviceSchema);

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -10,13 +10,11 @@
       "license": "ISC",
       "dependencies": {
         "bcrypt": "^5.1.1",
-        "body-parser": "^1.20.3",
         "cors": "^2.8.5",
         "dotenv": "^16.4.7",
         "express": "^4.21.2",
         "jsonwebtoken": "^9.0.2",
         "mongoose": "^8.9.5",
-        "mongoose-sequence": "^6.0.1",
         "multer": "^1.4.5-lts.1",
         "nodemailer": "^6.9.16"
       }
@@ -158,11 +156,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
-    },
-    "node_modules/async": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
-      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA=="
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -869,11 +862,6 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -1132,18 +1120,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mongoose"
-      }
-    },
-    "node_modules/mongoose-sequence": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/mongoose-sequence/-/mongoose-sequence-6.0.1.tgz",
-      "integrity": "sha512-uXnLCW9pu2V49Xw8BmdXdeRugd2mv+ntu3nT2Bbm33pNRmmvHE2GKA+8BASKoQt960McLX4VL78wkb492f6MoQ==",
-      "dependencies": {
-        "async": "^3.2.5",
-        "lodash": "^4.17.21"
-      },
-      "peerDependencies": {
-        "mongoose": ">=5"
       }
     },
     "node_modules/mongoose/node_modules/ms": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -11,13 +11,11 @@
   "license": "ISC",
   "dependencies": {
     "bcrypt": "^5.1.1",
-    "body-parser": "^1.20.3",
     "cors": "^2.8.5",
     "dotenv": "^16.4.7",
     "express": "^4.21.2",
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.9.5",
-    "mongoose-sequence": "^6.0.1",
     "multer": "^1.4.5-lts.1",
     "nodemailer": "^6.9.16"
   }

--- a/backend/routes/contact.js
+++ b/backend/routes/contact.js
@@ -8,8 +8,15 @@ const router = express.Router();
 router.post("/", async (req, res) => {
   const { name, email, message, services, "g-recaptcha-response": recaptchaToken } = req.body;
 
-  // Controleer op lege velden
-  if (!name || !email || !message || !services || !recaptchaToken) {
+  // Controleer op lege velden en lege services array
+  if (
+    !name ||
+    !email ||
+    !message ||
+    !Array.isArray(services) ||
+    services.length === 0 ||
+    !recaptchaToken
+  ) {
     return res.status(400).json({ error: "Alle velden en reCAPTCHA zijn verplicht." });
   }
 

--- a/backend/routes/messages.js
+++ b/backend/routes/messages.js
@@ -16,21 +16,15 @@ router.get("/", async (req, res) => {
 router.post("/", async (req, res) => {
   const { name, email, message, services } = req.body;
 
-  console.log("Incoming data:", req.body); // Debug log
-
   if (!name || !email || !message) {
-    console.log("Validation failed: Missing fields"); // Debug log
     return res.status(400).json({ error: "Alle velden zijn verplicht." });
   }
 
   try {
     const newMessage = new Message({ name, email, message, services });
-    const savedMessage = await newMessage.save();
-
-    console.log("Saved message:", savedMessage); // Debug log
+    await newMessage.save();
     res.status(201).json({ message: "Bericht opgeslagen!" });
   } catch (err) {
-    console.error("Error saving message to MongoDB:", err); // Debug log
     res.status(500).json({ error: "Kan het bericht niet opslaan" });
   }
 });
@@ -40,10 +34,10 @@ router.post("/", async (req, res) => {
 // Verwijder een bericht
 router.delete("/:id", async (req, res) => {
   try {
-    const message = await Message.findById(req.params.id);
-    if (!message) return res.status(404).json({ error: "Bericht niet gevonden" });
-
-    await message.remove();
+    const deletedMessage = await Message.findByIdAndDelete(req.params.id);
+    if (!deletedMessage) {
+      return res.status(404).json({ error: "Bericht niet gevonden" });
+    }
     res.json({ message: "Bericht verwijderd!" });
   } catch (err) {
     res.status(500).json({ error: "Kan het bericht niet verwijderen" });

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,7 +1,6 @@
 const express = require("express");
 const mongoose = require("mongoose");
 const cors = require("cors");
-const bodyParser = require("body-parser");
 require("dotenv").config();
 
 const app = express();
@@ -12,12 +11,10 @@ const corsOptions = {
   };
   
   app.use(cors(corsOptions));
-  
-  
+
 // Middleware
-app.use(cors());
 app.use(express.json());
-app.use(bodyParser.urlencoded({ extended: true }));
+app.use(express.urlencoded({ extended: true }));
 
 // Connect to MongoDB
 mongoose

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "react-scripts": "5.0.1",
     "web-vitals": "^4.2.4"
   },
-  "proxy": "http://MichaelRedant.github.io/marketeer",
+  "proxy": "http://localhost:5000",
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",

--- a/src/api.js
+++ b/src/api.js
@@ -1,4 +1,5 @@
-const API_BASE_URL = "http://localhost:5000/api";
+const API_BASE_URL =
+  process.env.REACT_APP_API_BASE_URL || "http://localhost:5000/api";
 
 // Algemene functie voor API-requests
 const apiCall = async (endpoint, method = "GET", body = null) => {
@@ -63,3 +64,6 @@ export const updateService = (id, service) =>
   apiCall(`services-admin/${id}`, "PUT", service);
 export const deleteService = (id) =>
   apiCall(`services-admin/${id}`, "DELETE");
+
+// Message API-calls
+export const sendMessage = (message) => apiCall("messages", "POST", message);

--- a/src/components/Contact.js
+++ b/src/components/Contact.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { useSearchParams } from "react-router-dom";
-import { fetchServices } from "../api"; // Zorg ervoor dat de API functie correct werkt
+import { fetchServices, sendMessage } from "../api"; // Zorg ervoor dat de API functies correct werken
 import "../contact.css"; // Voeg stijlen toe voor confetti-effect
 
 function Contact() {
@@ -58,23 +58,11 @@ function Contact() {
     e.preventDefault();
 
     try {
-      const response = await fetch("http://localhost:5000/api/messages", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(formData),
-      });
-
-      if (response.ok) {
-        setSuccessMessage("Bericht succesvol verzonden!");
-        setFormData({ name: "", email: "", message: "", services: [] });
-        setErrorMessage("");
-        triggerConfetti(); // Start confetti
-      } else {
-        const data = await response.json();
-        setErrorMessage(data.error || "Er is een fout opgetreden.");
-      }
+      await sendMessage(formData);
+      setSuccessMessage("Bericht succesvol verzonden!");
+      setFormData({ name: "", email: "", message: "", services: [] });
+      setErrorMessage("");
+      triggerConfetti(); // Start confetti
     } catch (err) {
       console.error("Error submitting form:", err);
       setErrorMessage("Kan geen verbinding maken met de server.");

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -29,7 +29,9 @@ function Header() {
               <NavLink to={path}>
                 {path === "/"
                   ? "Home"
-                  : path.substring(1).charAt(0).toUpperCase() + path.substring(2)}
+                  : path
+                      .slice(1)
+                      .replace(/^\w/, (c) => c.toUpperCase())}
               </NavLink>
             </li>
           ))}

--- a/src/components/Services.js
+++ b/src/components/Services.js
@@ -61,7 +61,11 @@ function Services() {
         <motion.div className="card-container" initial="hidden" animate="visible">
           {sortedServices.map((service) => (
             <div className={`card`} key={service.id}>
-              <a href="#" onClick={() => setSelectedService(service)}>
+              <button
+                type="button"
+                onClick={() => setSelectedService(service)}
+                className="w-full text-left"
+              >
                 <div className="card--display">
                   <i className="material-icons">{service.icon || "⤵️"}</i>
                   <h2>{service.name}</h2>
@@ -71,7 +75,7 @@ function Services() {
                   <p>{service.description}</p>
                   <p className="link">Klik voor meer informatie</p>
                 </div>
-              </a>
+              </button>
               <div className="card--border"></div>
             </div>
           ))}


### PR DESCRIPTION
## Summary
- streamline Express server middleware and remove unused dependencies
- validate contact service selections and persist them
- fix UI labels and convert service links to buttons

## Testing
- `CI=true npm test` *(fails: react-scripts not found)*
- `cd backend && npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_6891f29567308332aecba5272e201368