### PR TITLE
feat: add custom sitemap generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "sitemap": "node scripts/generate-sitemap.js"
   },
   "eslintConfig": {
     "extends": [

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://example.com/</loc>
+  </url>
+  <url>
+    <loc>https://example.com/about</loc>
+  </url>
+  <url>
+    <loc>https://example.com/services</loc>
+  </url>
+  <url>
+    <loc>https://example.com/werk</loc>
+  </url>
+  <url>
+    <loc>https://example.com/contact</loc>
+  </url>
+</urlset>

--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -1,0 +1,19 @@
+const fs = require('fs');
+const path = require('path');
+const routes = require('../src/routes.json');
+
+const hostname = process.env.SITE_URL || 'https://example.com';
+
+const urls = routes
+  .filter((route) => !route.startsWith('/admin'))
+  .map((route) => `  <url>\n    <loc>${hostname}${route}</loc>\n  </url>`)
+  .join('\n');
+
+const sitemap = `<?xml version="1.0" encoding="UTF-8"?>\n` +
+  `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n` +
+  `${urls}\n` +
+  `</urlset>`;
+
+fs.writeFileSync(path.resolve(__dirname, '../public/sitemap.xml'), sitemap);
+console.log('sitemap.xml generated');
+

--- a/src/App.js
+++ b/src/App.js
@@ -4,6 +4,7 @@ import { AnimatePresence, motion } from "framer-motion";
 import ScrollToTop from "./components/ScrollToTop";
 import Header from "./components/Header";
 import Footer from "./components/Footer";
+import routes from "./routes.json";
 import Home from "./components/Home";
 import About from "./components/About";
 import Services from "./components/Services";
@@ -33,61 +34,36 @@ const pageVariants = {
 function AnimatedRoutes() {
   const location = useLocation();
 
+  const routeComponents = {
+    "/": Home,
+    "/about": About,
+    "/services": Services,
+    "/werk": Werk,
+    "/contact": Contact,
+  };
+
   return (
     <AnimatePresence mode="wait">
       <Routes key={location.pathname} location={location}>
-        <Route
-          path="/"
-          element={
-            <motion.div
-              initial="initial"
-              animate="animate"
-              exit="exit"
-              variants={pageVariants}
-            >
-              <Home />
-            </motion.div>
-          }
-        />
-        <Route
-          path="/about"
-          element={
-            <motion.div
-              initial="initial"
-              animate="animate"
-              exit="exit"
-              variants={pageVariants}
-            >
-              <About />
-            </motion.div>
-          }
-        />
-        <Route
-          path="/services"
-          element={
-            <motion.div
-              initial="initial"
-              animate="animate"
-              exit="exit"
-              variants={pageVariants}
-            >
-              <Services />
-            </motion.div>
-          }
-        />
-        <Route
-          path="/werk"
-          element={
-            <motion.div
-              initial="initial"
-              animate="animate"
-              exit="exit"
-              variants={pageVariants}
-            >
-              <Werk />
-            </motion.div>
-          }
-        />
+        {routes.map((path) => {
+          const Component = routeComponents[path];
+          return (
+            <Route
+              key={path}
+              path={path}
+              element={
+                <motion.div
+                  initial="initial"
+                  animate="animate"
+                  exit="exit"
+                  variants={pageVariants}
+                >
+                  <Component />
+                </motion.div>
+              }
+            />
+          );
+        })}
         {/* Admin Dashboard Route */}
         <Route
           path="/admin/*" // Gebruik * zodat nested routes binnen AdminPanel werken
@@ -99,19 +75,6 @@ function AnimatedRoutes() {
               variants={pageVariants}
             >
               <AdminPanel />
-            </motion.div>
-          }
-        />
-        <Route
-          path="/contact"
-          element={
-            <motion.div
-              initial="initial"
-              animate="animate"
-              exit="exit"
-              variants={pageVariants}
-            >
-              <Contact />
             </motion.div>
           }
         />

--- a/src/routes.json
+++ b/src/routes.json
@@ -1,0 +1,7 @@
+[
+  "/",
+  "/about",
+  "/services",
+  "/werk",
+  "/contact"
+]


### PR DESCRIPTION
## Summary
- add configurable sitemap generation script
- centralize route definitions for reuse

## Testing
- `npm run sitemap`
- `npm install --legacy-peer-deps --no-audit --no-fund` *(fails: ENOTEMPTY: directory not empty, rename '/workspace/marketeer/node_modules/ajv-formats')*
- `npm test -- --watchAll=false` *(fails: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_b_689200b5b73083328b43c18c156fd2de